### PR TITLE
Use ENTRYPOINT instead of CMD so we can easily add parameters to dock…

### DIFF
--- a/apiman-wildfly/Dockerfile
+++ b/apiman-wildfly/Dockerfile
@@ -8,5 +8,5 @@ RUN cd $JBOSS_HOME \
  && bsdtar -xf apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
  && rm apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip
 
-CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-c", "standalone-apiman.xml"]
+ENTRYPOINT ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-c", "standalone-apiman.xml"]
 


### PR DESCRIPTION
Use ENTRYPOINT instead of CMD so we can easily add parameters to docker run instead copying the whole CMD when we want to add a parameter. For example when we want to add a system property to wildfly using -D.

With CMD we need to do:
docker run -ti jboss/apiman-wildfly:1.2.0.Final /opt/jboss/wildfly/bin/standalone.sh -b=0.0.0.0 -c=standalone-apiman.xml -Dproperty=value

With ENTRYPOINT we can just do:
docker run -ti jboss/apiman-wildfly:1.2.0.Final -Dproperty=value

and get the same result.
